### PR TITLE
Fix dts file location

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,15 +7,17 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/kasperpeulen/simply-effect.git"
+    "url": "git+https://github.com/kasperpeulen/simply-effect.git"
   },
   "homepage": "https://github.com/kasperpeulen/simply-effect",
   "bugs": {
     "url": "https://github.com/kasperpeulen/simply-effect/issues"
   },
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/dts/index.d.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.6--canary.6.068c435.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install simply-effect@0.0.6--canary.6.068c435.0
  # or 
  yarn add simply-effect@0.0.6--canary.6.068c435.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
